### PR TITLE
subject doesn't receive ExampleGroup instance anymore

### DIFF
--- a/spec/aws/file_bucket_spec.rb
+++ b/spec/aws/file_bucket_spec.rb
@@ -6,7 +6,7 @@ describe GyomuRuby::AWS::FileBucket::RichMan do
   describe '.store_options' do
     let(:options) { GyomuRuby::AWS::FileBucket::RichMan.store_options(content) }
     let(:root) { Pathname.new(File.dirname(__FILE__) + '/../../') }
-    subject &:options
+    subject { options }
 
     context 'store Image files' do
       let(:content) { File.open(root + 'spec/fixtures/images/esm-gravater.png', 'r:BINARY') }


### PR DESCRIPTION
RSpec 2.13 以降では `subject` の実装が変わり ExampleGroup のインスタンスが渡されなくなりました。

https://github.com/rspec/rspec-core/commit/c5172be7378fcadf2b468c6d0ed367bb7471985c
